### PR TITLE
Add explicit disqus identifiers

### DIFF
--- a/templates/_includes/disqus_script.html
+++ b/templates/_includes/disqus_script.html
@@ -3,6 +3,7 @@
 	  {% if article %}
           var disqus_identifier = '{{ SITEURL }}/{{ article.url }}';
           var disqus_url = '{{ SITEURL }}/{{ article.url }}';
+	  var disqus_title = '{{ article.title }}';
 	  {% endif %}
 	  var disqus_shortname = '{{ DISQUS_SITENAME }}';
 	  (function() {


### PR DESCRIPTION
This PR adds explicit Disqus article identifiers for the Disqus include.  Without these, the script attempts to guess the values from the page URL.  This can be unreliable: e.g. if your site is on github pages, the recent switch to `github.io` addresses could cause a loss of comments.
