### PR TITLE
add header extra args

### DIFF
--- a/templates/_includes/head.html
+++ b/templates/_includes/head.html
@@ -16,6 +16,10 @@
         title="{{ SITENAME }} RSS Feed" />
   {% endif %}
 
+  {% if EXTRA_HEADER %}
+    {{ EXTRA_HEADER }}
+  {% endif %}
+
   <!-- http://t.co/dKP3o1e -->
   <meta name="HandheldFriendly" content="True">
   <meta name="MobileOptimized" content="320">


### PR DESCRIPTION
This adds a simple statement allowing the inclusion of extra html within the base header.  This is useful in certain circumstances, e.g. adding an HTML-rendered ipython notebook to the blog (see my pelican-plugins PR: https://github.com/getpelican/pelican-plugins/pull/21)
