### PR TITLE
Add site search settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,10 @@ You can enable it by using these settings:
 - ``GITHUB_SKIP_FORK``: False
 - ``GITHUB_SHOW_USER_LINK``: False
 
+- ``SEARCH_BOX``: set to true to enable site search box
+- ``SITESEARCH``: [default: 'http://google.com/search'] search engine to which
+  search form should be pointed (optional)
+
 Contribute
 ----------
 

--- a/templates/_includes/navigation.html
+++ b/templates/_includes/navigation.html
@@ -5,14 +5,15 @@
   {% endif %}
 </ul>
 
-<!-- TODO: add search here
-<form action="{{ SITESEARCH }}" method="get">
+
+{% if SEARCH_BOX %}
+<form action="{{ SITESEARCH|default('http://google.com/search') }}" method="get">
   <fieldset role="search">
-    <input type="hidden" name="q" value="site:{{ SITEURL }}" />
+    <input type="hidden" name="q" value="site:{{ SITEURL|replace('http://','') }}" />
     <input class="search" type="text" name="q" results="0" placeholder="Search"/>
   </fieldset>
 </form>
--->
+{% endif %}
 
 <ul class="main-navigation">
   <li><a href="{{ SITEURL }}/">Blog</a></li>


### PR DESCRIPTION
This PR adds settings controlling a custom search box for the site:
- `SEARCH_BOX`: set to true to enable site search box
- `SITESEARCH`: [default: 'http://google.com/search'] search engine to which
  search form should be pointed (optional)
