### PR TITLE
Remove hard connection between SITEURL and 'Blog' in navbar

### DIFF
--- a/templates/_includes/navigation.html
+++ b/templates/_includes/navigation.html
@@ -15,7 +15,6 @@
 -->
 
 <ul class="main-navigation">
-  <li><a href="{{ SITEURL }}/">Blog</a></li>
   {% for title, link in MENUITEMS %}
     <li><a href="{{ link }}">{{ title }}</a></li>
   {% endfor %}


### PR DESCRIPTION
This small change removes the "Blog" -> `SITEURL` entry in the navigation. The `MENUITEMS` setting now fully controls the contents of the navbar, which is important if the user is defining a custom landing page for a site and doesn't want to identify the `SITEURL` as `Blog`, or if they want to call it something else (e.g. `NOTES`). This is the general convention used in the Pelican default theme as well. 
