### PR TITLE
Restore js vars

### DIFF
--- a/templates/_includes/disqus_script.html
+++ b/templates/_includes/disqus_script.html
@@ -1,7 +1,11 @@
 {% if DISQUS_SITENAME %}
 	<script type="text/javascript">
-	  var disqus_shortname = '{{ DISQUS_SITENAME }}';
-	  var disqus_identifier = window.location.pathname;
+    var disqus_shortname = '{{ DISQUS_SITENAME }}';
+    {% if article %}
+        var disqus_identifier = '/{{ article.url }}';
+        var disqus_url = '{{ SITEURL }}/{{ article.url }}';
+        var disqus_title = '{{ article.title }}';
+    {% endif %}
 	  (function() {
 	    var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
 	    dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';


### PR DESCRIPTION
Restore disqus js vars; disqus_identifier doesn't contain SITEURL anymore, probably for a bit more portability (that's [DIsqus's suggestion](http://help.disqus.com/customer/portal/articles/472098-javascript-configuration-variables) as well)
