### PR TITLE
Restore disqus js variables

### DIFF
--- a/templates/_includes/disqus_script.html
+++ b/templates/_includes/disqus_script.html
@@ -1,6 +1,11 @@
 {% if DISQUS_SITENAME %}
 	<script type="text/javascript">
 	  var disqus_shortname = '{{ DISQUS_SITENAME }}';
+      {% if article %}
+          var disqus_identifier = '/{{ article.url }}';
+          var disqus_url = '{{ SITEURL }}/{{ article.url }}';
+          var disqus_title = '{{ article.title }}';
+      {% endif %}
 	  (function() {
 	    var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
 	    dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';


### PR DESCRIPTION
`disqus_identifier` now doesn't include SITEURL for portability
