### PR TITLE
Added SITENAME to page template

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% block title %}{{ page.title }}{% endblock %}
+{% block title %}{{ page.title }} | {{ SITENAME }} {% endblock %}
 {% block content %}
 <div>
   <article role="article">


### PR DESCRIPTION
Instead of rendering just a page title now it shows also the site name, this is handy when browsing with multiple tabs opened and all you see are titles, something like "Projects" doesn't say much, but "Projects | Joe's Blog" is way more descriptive.
