### PR TITLE
Replace copyright with custom license in footer

### DIFF
--- a/templates/_includes/footer.html
+++ b/templates/_includes/footer.html
@@ -1,4 +1,4 @@
 <p>
-  Copyright &copy; 2013 - {{ AUTHOR }} -
+  {{ LICENSE }}<br />
   <span class="credit">Powered by <a href="http://getpelican.com">Pelican</a></span>
 </p>


### PR DESCRIPTION
Replace copyright with custom license in footer.
