### PR TITLE
Social plugin only shows RSS/Atom feeds if available

### DIFF
--- a/templates/_includes/social.html
+++ b/templates/_includes/social.html
@@ -3,7 +3,12 @@
     <section>
         <h1>Social</h2>
         <ul>
+        {% if FEED_RSS %}
             <li><a href="{{ FEED_DOMAIN }}/{{ FEED_RSS }}" type="application/rss+xml" rel="alternate">RSS</a></li>
+        {% endif %}
+        {% if FEED_ATOM %}
+            <li><a href="{{ FEED_DOMAIN }}/{{ FEED_ATOM }}" type="application/atom+xml" rel="alternate">Atom</a></li>
+        {% endif %}
         {% for name, link in SOCIAL %}
             <li><a href="{{ link }}" target="_blank">{{ name }}</a></li>
         {% endfor %}


### PR DESCRIPTION
As it currently is, for blogs that don't have RSS feeds enabled, an "RSS" link is still displayed which points to the domain only. This commit adds a condition as well as an Atom alternative.
