### PR TITLE
Add custom license with fallback to defaults

### DIFF
--- a/templates/_includes/footer.html
+++ b/templates/_includes/footer.html
@@ -1,4 +1,8 @@
 <p>
-  Copyright &copy; 2013 - {{ AUTHOR }} -
+  {% if LICENSE %}
+      {{ LICENSE }} 
+  {% else %}
+      Copyright &copy; 2014 - {{ AUTHOR }} -
+  {% endif %}
   <span class="credit">Powered by <a href="http://getpelican.com">Pelican</a></span>
 </p>


### PR DESCRIPTION
This is a remake of pull #41 as @duilio requested.

If LICENSE is defined then use it on footer, otherwise fallback to defaults.
