### PR TITLE
use protocol-relative urls to adapt to https blogs

### DIFF
--- a/templates/_includes/disqus_script.html
+++ b/templates/_includes/disqus_script.html
@@ -8,7 +8,7 @@
       {% endif %}
 	  (function() {
 	    var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-	    dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+	    dsq.src = "//" + disqus_shortname + '.disqus.com/embed.js';
 	    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 	   })();
 	</script>

--- a/templates/_includes/gplus_sidebar.html
+++ b/templates/_includes/gplus_sidebar.html
@@ -2,7 +2,7 @@
 <section class="googleplus{% if GOOGLE_PLUS_HIDDEN %} googleplus-hidden{% endif %}">
   <h1>
     <a href="https://plus.google.com/{{ GOOGLE_PLUS_ID }}?rel=author">
-      <img src="http://www.google.com/images/icons/ui/gprofile_button-32.png" width="32" height="32">
+      <img src="//www.google.com/images/icons/ui/gprofile_button-32.png" width="32" height="32">
       Google+
     </a>
   </h1>

--- a/templates/_includes/navigation.html
+++ b/templates/_includes/navigation.html
@@ -9,7 +9,7 @@
 
 
 {% if SEARCH_BOX %}
-<form action="{{ SITESEARCH|default('http://google.com/search') }}" method="get">
+<form action="{{ SITESEARCH|default('//google.com/search') }}" method="get">
   <fieldset role="search">
     {% if 'duckduckgo.com' in SITESEARCH|lower %}
     <input type="hidden" name="sites" value="{{SITEURL|replace('https://','')|replace('http://','') }}" />

--- a/templates/_includes/piwik.html
+++ b/templates/_includes/piwik.html
@@ -13,5 +13,5 @@
         piwikTracker.enableLinkTracking();
         } catch( err ) {}
     </script>
-    <noscript><p><img src="http://{{ PIWIK_URL }}/piwik.php?idsite={{ PIWIK_SITE_ID }}" style="border:0" alt="" /></p></noscript>
+    <noscript><p><img src="//{{ PIWIK_URL }}/piwik.php?idsite={{ PIWIK_SITE_ID }}" style="border:0" alt="" /></p></noscript>
 {% endif %}

--- a/templates/_includes/twitter_sharing.html
+++ b/templates/_includes/twitter_sharing.html
@@ -4,7 +4,7 @@
       var twitterWidgets = document.createElement('script');
       twitterWidgets.type = 'text/javascript';
       twitterWidgets.async = true;
-      twitterWidgets.src = 'http://platform.twitter.com/widgets.js';
+      twitterWidgets.src = '//platform.twitter.com/widgets.js';
       document.getElementsByTagName('head')[0].appendChild(twitterWidgets);
     })();
   </script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,9 +32,9 @@
   <script src="{{ SITEURL }}/theme/js/ender.js"></script>
   <script src="{{ SITEURL }}/theme/js/octopress.js" type="text/javascript"></script>
 
-  <link href="http://fonts.googleapis.com/css?family=PT+Serif:regular,italic,bold,bolditalic"
+  <link href="//fonts.googleapis.com/css?family=PT+Serif:regular,italic,bold,bolditalic"
         rel="stylesheet" type="text/css">
-  <link href="http://fonts.googleapis.com/css?family=PT+Sans:regular,italic,bold,bolditalic"
+  <link href="//fonts.googleapis.com/css?family=PT+Sans:regular,italic,bold,bolditalic"
         rel="stylesheet" type="text/css">
   {% if article and article.latex %}
     {{ article.latex }}


### PR DESCRIPTION
My blog is running https (and I believe some others will, too). Load resources using [protocol-relative](http://www.paulirish.com/2010/the-protocol-relative-url/) urls.
