### PR TITLE
show article neighbors under article

### DIFF
--- a/templates/_includes/article_neighbors.html
+++ b/templates/_includes/article_neighbors.html
@@ -1,0 +1,10 @@
+{% if SHOW_ARTICLE_NEIGHBORS %}
+<p class="meta">
+{% if article.prev_article %}
+  <a class="basic-alignment left" href="{{ SITEURL }}/{{ article.prev_article.url }}" title="Previous Post: {{ article.prev_article.title}}">&laquo; {{ article.prev_article.title }}</a>
+{% endif %}
+{% if article.next_article %}
+  <a class="basic-alignment right" href="{{ SITEURL }}/{{ article.next_article.url }}" title="Next Post: {{ article.next_article.title}}">{{ article.next_article.title }} &raquo;</a>
+{% endif %}
+</p>
+{% endif %}

--- a/templates/article.html
+++ b/templates/article.html
@@ -6,6 +6,7 @@
     {% include '_includes/article.html' %}
     <footer>
       {% include '_includes/article_infos.html' %}
+      {% include '_includes/article_neighbors.html' %}
       {% include '_includes/sharing.html' %}
     </footer>
   </article>


### PR DESCRIPTION
Show links to "Previous Post" and "Next Post" bellow article content in article pages.

To enable this feature, set ``SHOW_ARTICLE_NEIGHBORS = True`` in ``pelicanconf.py``.