### PR TITLE
Show comment count in article meta

### DIFF
--- a/templates/_includes/article.html
+++ b/templates/_includes/article.html
@@ -7,7 +7,10 @@
     {% else %}
       <h1 class="entry-title">{{ article.title|striptags }}</h1>
     {% endif %}
-      <p class="meta">{% include '_includes/article_time.html' %}</p>
+      <p class="meta">
+        {% include '_includes/article_time.html' %}
+        {% if DISQUS_SITENAME %} | <a href="{{ SITEURL }}/{{ article.url }}#disqus_thread">Comments</a>{% endif %}
+      </p>
 </header>
 
 {% if index %}

--- a/templates/_includes/article.html
+++ b/templates/_includes/article.html
@@ -9,7 +9,9 @@
     {% endif %}
       <p class="meta">
         {% include '_includes/article_time.html' %}
+        {% if SHOW_DISQUS_COMMENT_COUNT %}
         {% if DISQUS_SITENAME %} | <a href="{{ SITEURL }}/{{ article.url }}#disqus_thread">Comments</a>{% endif %}
+        {% endif %}
       </p>
 </header>
 

--- a/templates/_includes/disqus_script.html
+++ b/templates/_includes/disqus_script.html
@@ -8,7 +8,12 @@
       {% endif %}
 	  (function() {
 	    var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-	    dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+	    dsq.src = "//" + disqus_shortname + '.disqus.com/embed.js';
+	    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+	   })();
+	  (function() {
+	    var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+	    dsq.src = "//" + disqus_shortname + '.disqus.com/count.js';
 	    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 	   })();
 	</script>


### PR DESCRIPTION
Show comment count in article meta paragraph. controls with ``SHOW_DISQUS_COMMENT_COUNT``.

Due to merge conflict with branch ``https`` (both change templates/_includes/disqus_script.html), I have merged that branch into this merge request.