### PR TITLE
add a switch to turn off sidebar

### DIFF
--- a/templates/_includes/sidebar.html
+++ b/templates/_includes/sidebar.html
@@ -1,3 +1,4 @@
+{% if sidebar != "off" %}
 <aside class="sidebar">
   {% if SIDEBAR_IMAGE %}
   <section>
@@ -39,3 +40,4 @@
   {% include '_includes/twitter_sidebar.html' %}
   {% include '_includes/gplus_sidebar.html' %}
 </aside>
+{% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -44,7 +44,15 @@
   {% endif %}
 </head>
 
-<body>
+{% if page %}
+  {% set sidebar = page.sidebar|default("on") %}
+{% elif article %}
+  {% set sidebar = article.sidebar|default("on") %}
+{% else %}
+  {% set sidebar = "on" %}
+{% endif %}
+{% set sidebar = sidebar|string|lower|replace("true", "on")|replace("false", "off") %}
+<body {% if sidebar == "off" %} class="no-sidebar" {% endif %}>
   <header role="banner">{% include '_includes/header.html' %}</header>
   <nav role="navigation">{% include '_includes/navigation.html' %}</nav>
   <div id="main">


### PR DESCRIPTION
Sometimes we don't need a sidebar for some pages, e.g. a biography page. Add a switch to control whether show the sidebar.

One can control whether show sidebar for a specific page or article by define a `sidebar` meta. Like

```
Title: Biography
Author: Awesome one
Slug: biography
Sidebar: off
```

Values can be `on`, `off`, `true`, `false`, case insensitive, internally they are converted to lower case `on` or `off`.
