### PR TITLE
add a switch to control whether comments is enabled for specific page

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -10,7 +10,9 @@
     </footer>
   </article>
 
-  {% if DISQUS_SITENAME and SITEURL and article.status != "draft" %}
+  {% set comments = article.comments|default("on") %}
+  {% set comments = comments|string|lower|replace("true", "on")|replace("false", "off") %}
+  {% if comments != "off" and DISQUS_SITENAME and SITEURL and article.status != "draft" %}
   <section>
     <h1>Comments</h1>
     <div id="disqus_thread" aria-live="polite">{% include '_includes/disqus_thread.html' %}</div>

--- a/templates/page.html
+++ b/templates/page.html
@@ -9,5 +9,14 @@
     </header>
     {{ page.content }}
   </article>
+
+  {% set comments = page.comments|default("off") %}
+  {% set comments = comments|string|lower|replace("true", "on")|replace("false", "off") %}
+  {% if comments != "off" and DISQUS_SITENAME and SITEURL %}
+  <section>
+    <h1>Comments</h1>
+    <div id="disqus_thread" aria-live="polite">{% include '_includes/disqus_thread.html' %}</div>
+  </section>
+  {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
* ``page`` sometimes also need comments, we should allow that.
* ``article`` sometimes may want't to disable comments

Put ``Comments: off`` in article meta to disable comments for the specific article. To remain compatible, page comments are disabled by default, use ``Comments: on`` to turn on.