### PR TITLE
added missing templates, consistent site title on all pages

### DIFF
--- a/templates/archives.html
+++ b/templates/archives.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ SITENAME }} Archive {% endblock %}
+{% block title %}Blog Archive &mdash; {{ SITENAME }}{% endblock %}
 {% block content %}
 <div>
 	<article role="article">

--- a/templates/article.html
+++ b/templates/article.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ article.title|striptags }}{% endblock %}
+{% block title %}{{ article.title|striptags }} &mdash; {{ SITENAME }}{% endblock %}
 {% block content %}
 <div>
   <article class="hentry" role="article">

--- a/templates/author.html
+++ b/templates/author.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
-{% block title %}Tag: {{ tag }} &mdash; {{ SITENAME }}{% endblock %}
+{% block title %}Author: {{ author }} &mdash; {{ SITENAME }}{% endblock %}
 {% block content %}
 <div>
 	<article role="article">
     	<header>
-    		<h1 class="entry-title">Tag: {{ tag }}</h1>
+    		<h1 class="entry-title">Author: {{ author }}</h1>
     	</header>
 
     	<div id="blog-archives">

--- a/templates/authors.html
+++ b/templates/authors.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block title %}Authors &mdash; {{ SITENAME }}{% endblock %}
+{% block content %}
+<div>
+	<article role="article">
+    	<header>
+    		<h1 class="entry-title">Blog Authors</h1>
+    	</header>
+
+	{% for author, articles in authors|sort %}
+		<p><a href="{{ SITEURL }}/{{ author.url }}">{{ author.name }}</a> ({{ articles|count }})</p>
+	{% endfor %}
+	</article>
+</div>
+{% endblock %}

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}Categories &mdash; {{ SITENAME }}{% endblock %}
+{% block content %}
+<div>
+	<article role="article">
+    	<header>
+    		<h1 class="entry-title">Blog Categories</h1>
+    	</header>
+
+	<p>
+	{% for category, articles in categories|sort %}
+		<a href="{{ SITEURL }}/{{ category.url }}">{{ category.name }}</a> ({{ articles|count }})<br>
+	{% endfor %}
+	</p>
+	</article>
+</div>
+{% endblock %}

--- a/templates/category.html
+++ b/templates/category.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
-{% block title %}Tag: {{ tag }} &mdash; {{ SITENAME }}{% endblock %}
+{% block title %}Category: {{ category }} &mdash; {{ SITENAME }}{% endblock %}
 {% block content %}
 <div>
 	<article role="article">
     	<header>
-    		<h1 class="entry-title">Tag: {{ tag }}</h1>
+    		<h1 class="entry-title">Category: {{ category }}</h1>
     	</header>
 
     	<div id="blog-archives">

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% block title %}{{ page.title }} | {{ SITENAME }} {% endblock %}
+{% block title %}{{ page.title }} &mdash; {{ SITENAME }}{% endblock %}
 {% block content %}
 <div>
   <article role="article">

--- a/templates/period_archives.html
+++ b/templates/period_archives.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
-{% block title %}Tag: {{ tag }} &mdash; {{ SITENAME }}{% endblock %}
+{% block title %}Archive &ndash; {{ period[2] }} {{ period[1] }} {{ period[0]  }} &mdash; {{ SITENAME }}{% endblock %}
 {% block content %}
 <div>
 	<article role="article">
     	<header>
-    		<h1 class="entry-title">Tag: {{ tag }}</h1>
+    	  <h1 class="entry-title">Blog Archive &ndash; {{ period[2] }} {{ period[1] }} {{ period[0]  }}</h1>
     	</header>
 
     	<div id="blog-archives">
@@ -22,6 +22,7 @@
                         <footer>
                             <span class="categories">posted in
                                 <a class='category' href='{{ SITEURL }}/{{ article.category.url }}'>{{ article.category }}</a>
+                                {{ tag }}
                             </span>
 			    {% include '_includes/article_stats.html' %}
                         </footer>

--- a/templates/tags.html
+++ b/templates/tags.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}Tags &mdash; {{ SITENAME }}{% endblock %}
+{% block content %}
+<div>
+	<article role="article">
+    	<header>
+    		<h1 class="entry-title">Blog Tags</h1>
+    	</header>
+
+	<p>
+	{% for tag, articles in tags|sort %}
+		<a href="{{ SITEURL }}/{{ tag.url }}">{{ tag.name }}</a> ({{ articles|count }})<br>
+	{% endfor %}
+	</p>
+	</article>
+</div>
+{% endblock %}


### PR DESCRIPTION
new templates:

 - author.html
 - authors.html
 - category.html
 - categories.html
 - period_archives.html
 - tags.html

updated template:

 - archives.html: site title
 - article.html: site title
 - page.html: site title
 - tag.html: extend base.html instead of index.html
   give the page a proper look as well as a explaining <h1>
   (author.html + category.html share the same look,
   just the explaining <h1> differs)