### PR TITLE
main navigation extended

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,18 @@ Favicon
 - ``FAVICON_FILENAME``: set to path of your favicon. The default is empty in
   which case the template will use the hardcoded address ``favicon.png``.
 
+Main Navigation (menu bar)
+--------------------------
+
+- ``DISPLAY_PAGES_ON_MENU``: ``True`` show pages
+- ``DISPLAY_CATEGORIES_ON_MENU``: ``True`` show categories
+- ``DISPLAY_FEEDS_ON_MENU``: ``False`` show feed icons (on the very right side)
+- ``MENUITEMS``: ``()`` show static links (before categories)
+- ``MENUITEMS_MIDDLE``: ``()`` show static links (between pages and categories)
+  e.g.: ``MENUITEMS_MIDDLE = ( ('link1', '/static/file1.zip'), )``
+- ``MENUITEMS_AFTER``: ``()`` show static links (after categories)
+  e.g.: ``MENUITEMS_AFTER = ( ('link2', '/static/file2.pdf'), )``
+
 Contribute
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ Main Navigation (menu bar)
 
 - ``DISPLAY_PAGES_ON_MENU``: ``True`` show pages
 - ``DISPLAY_CATEGORIES_ON_MENU``: ``True`` show categories
-- ``DISPLAY_FEEDS_ON_MENU``: ``False`` show feed icons (on the very right side)
+- ``DISPLAY_FEEDS_ON_MENU``: ``True`` show feed icons (on the very right side)
 - ``MENUITEMS``: ``()`` show static links (before categories)
 - ``MENUITEMS_MIDDLE``: ``()`` show static links (between pages and categories)
   e.g.: ``MENUITEMS_MIDDLE = ( ('link1', '/static/file1.zip'), )``

--- a/templates/_includes/navigation.html
+++ b/templates/_includes/navigation.html
@@ -1,4 +1,4 @@
-{% if DISPLAY_FEEDS_ON_MENU %}
+{% if DISPLAY_FEEDS_ON_MENU != False %}
 <ul class="subscription" data-subscription="rss">
   {% if FEED_FEEDBURNER %}
   <li><a href="http://feeds.feedburner.com/{{ FEED_FEEDBURNER }}" rel="subscribe-rss">RSS</a></li>

--- a/templates/_includes/navigation.html
+++ b/templates/_includes/navigation.html
@@ -1,4 +1,4 @@
-{% if DISPLAY_FEEDS_ON_MENU != False %}
+{% if DISPLAY_FEEDS_ON_MENU|default(true) %}
 <ul class="subscription" data-subscription="rss">
   {% if FEED_FEEDBURNER %}
   <li><a href="http://feeds.feedburner.com/{{ FEED_FEEDBURNER }}" rel="subscribe-rss">RSS</a></li>

--- a/templates/_includes/navigation.html
+++ b/templates/_includes/navigation.html
@@ -1,3 +1,4 @@
+{% if DISPLAY_FEEDS_ON_MENU %}
 <ul class="subscription" data-subscription="rss">
   {% if FEED_FEEDBURNER %}
   <li><a href="http://feeds.feedburner.com/{{ FEED_FEEDBURNER }}" rel="subscribe-rss">RSS</a></li>
@@ -10,7 +11,7 @@
   {% endif %}
   {% endif %}
 </ul>
-
+{% endif %}
 
 {% if SEARCH_BOX %}
 <form action="{{ SITESEARCH|default('//google.com/search') }}" method="get">
@@ -33,12 +34,22 @@
     {% for page in PAGES %}
       <li><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></li>
     {% endfor %}
-    {% if DISPLAY_CATEGORIES_ON_MENU %}
-    {% for cat, null in categories %}
-    <li {% if cat == category %}class="active"{% endif %}>
-    <a href="{{ SITEURL }}/{{ cat.url }}">{{ cat | capitalize }}</a>
-    </li>
+  {% endif %}
+  {% if MENUITEMS_MIDDLE %}
+    {% for title, link in MENUITEMS_MIDDLE %}
+      <li><a href="{{ link }}">{{ title }}</a></li>
     {% endfor %}
-    {% endif %}
+  {% endif %}
+  {% if DISPLAY_CATEGORIES_ON_MENU %}
+    {% for cat, null in categories %}
+      <li {% if cat == category %}class="active"{% endif %}>
+        <a href="{{ SITEURL }}/{{ cat.url }}">{{ cat | capitalize }}</a>
+      </li>
+    {% endfor %}
+  {% endif %}
+  {% if MENUITEMS_AFTER %}
+    {% for title, link in MENUITEMS_AFTER %}
+      <li><a href="{{ link }}">{{ title }}</a></li>
+    {% endfor %}
   {% endif %}
 </ul>


### PR DESCRIPTION
- Display feed icons in the main navigation only if requested.

- Categories can now be display in the main navigation independently of the
  setting if pages are displayed or not.

- a new MENUITEMS_MIDDLE and MENUITEMS_AFTER can be used to add links to the
  main navigation in this specific locations.