### PR TITLE
sidebar extended

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,7 @@ Sidebar image
 - ``SIDEBAR_IMAGE``: Adds specified image to sidebar. Example value: "images/author_photo.jpg"
 - ``SIDEBAR_IMAGE_ALT``: Alternative text for sidebar image
 - ``SIDEBAR_IMAGE_WIDTH``: Width of sidebar image
+- ``AUTHOR_ABOUT``: ```` the specified ``SIDEBAR_IMAGE`` is only shown if this is filled.
 
 - ``SEARCH_BOX``: set to true to enable site search box
 - ``SITESEARCH``: [default: 'http://google.com/search'] search engine to which
@@ -93,6 +94,13 @@ FeedBurner integration
   displayed feed URL to your FeedBurner URL. This also disables generation of the RSS and ATOM tags, regardless of whether
   you've set the ``FEED_RSS`` or ``FEED_ATOM`` variables. This way, you can arbitrarily set your generated feed URL while
   presenting your FeedBurner URL to your users.
+
+Sidebar
+-------
+
+- ``DISPLAY_CATEGORIES``: ``False`` show categories
+- ``DISPLAY_TAGS``: ``False`` show tags
+- ``DISPLAY_FEEDS``: ``False`` show feeds in Social section
 
 Contribute
 ----------

--- a/templates/_includes/sidebar.html
+++ b/templates/_includes/sidebar.html
@@ -1,8 +1,17 @@
 <aside class="sidebar">
-  {% if SIDEBAR_IMAGE %}
-  <section>
-	  <img src="{{ SITEURL }}/{{ SIDEBAR_IMAGE }}" alt="{{ SIDEBAR_IMAGE_ALT}}" width="{{SIDEBAR_IMAGE_WIDTH}}"/> 
-  </section>
+  {% if AUTHOR_ABOUT %}
+    <section>
+      <h1>About</h1>
+      <p>
+        {% if SIDEBAR_IMAGE %}
+          <img src="{{ SITEURL }}/{{ SIDEBAR_IMAGE }}" alt="{{ SIDEBAR_IMAGE_ALT}}" width="{{SIDEBAR_IMAGE_WIDTH}}" style="margin-left: 1em; float: right"/>
+	  {{ AUTHOR_ABOUT }}
+	  <br clear="all">
+        {% else %}
+          {{ AUTHOR_ABOUT }}
+        {% endif %}
+      </p>
+    </section>
   {% endif %}
   <section>
     <h1>Recent Posts</h1>
@@ -14,24 +23,25 @@
       {% endfor %}
     </ul>
   </section>
-  {% if categories %}
+  {% if DISPLAY_CATEGORIES and categories %}
   <section>
-      
     <h1>Categories</h1>
     <ul id="recent_posts">
       {% for category, articles in categories %}
-        <li><a href="{{ SITEURL }}/{{ category.url }}">{{ category }}</a></li>
+	<li><a href="{{ SITEURL }}/{{ category.url }}">{{ category }} ({{ articles|count }})</a></li>
       {% endfor %}
     </ul>
   </section>
   {% endif %} 
 
+  {% if DISPLAY_TAGS and tags %}
   <section>
-  <h1>Tags</h1>
-  {% for tag, article in tags %}
-    <a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a>{% if not loop.last %},{% endif %}
-  {% endfor %}
+    <h1>Tags</h1>
+    {% for tag, article in tags %}
+      <a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a>{% if not loop.last %},{% endif %}
+    {% endfor %}
   </section>
+  {% endif %} 
 
   {% include '_includes/github.html' %}
   {% include '_includes/social.html' %}

--- a/templates/_includes/social.html
+++ b/templates/_includes/social.html
@@ -1,13 +1,14 @@
-
 {% if SOCIAL %}
     <section>
         <h1>Social</h1>
         <ul>
-        {% if FEED_RSS %}
+        {% if DISPLAY_FEEDS %}
+          {% if FEED_RSS %}
             <li><a href="{{ FEED_DOMAIN }}/{{ FEED_RSS }}" type="application/rss+xml" rel="alternate">RSS</a></li>
-        {% endif %}
-        {% if FEED_ATOM %}
+          {% endif %}
+          {% if FEED_ATOM %}
             <li><a href="{{ FEED_DOMAIN }}/{{ FEED_ATOM }}" type="application/atom+xml" rel="alternate">Atom</a></li>
+          {% endif %}
         {% endif %}
         {% for name, link in SOCIAL %}
             <li><a href="{{ link }}" target="_blank">{{ name }}</a></li>


### PR DESCRIPTION
- display categories and tags in the sidebar only if requested
- display feeds in social section of the sidebar only if requested
- SIDEBAR_IMAGE + AUTHOR_ABOUT:
  
  SIDEBAR_IMAGE wont be shown unless AUTHOR_ABOUT is also set
  
  That whole sidebar image was a mess-- still is, just a little less so. only the
  image would look like spit. it would not have proper margins as there would be
  no section heading. so we won't allow it (for now).
  
  If AUTHOR_ABOUT is set then a section with the heading "About" gets rendered.
  Within this section a possibly set SIDEBAR_IMAGE gets displayed. It will be
  floating to the right. Proper margins will be set to have the text of
  AUTHOR_ABOUT not touch the SIDEBAR_IMAGE.
