### PR TITLE
author's name gets link only if AUTHORS_SAVE_AS is set.

### DIFF
--- a/templates/_includes/article_infos.html
+++ b/templates/_includes/article_infos.html
@@ -1,7 +1,11 @@
 <p class="meta">
   <span class="byline author vcard">
     Posted by <span class="fn">
-      <a href="{{ SITEURL }}/{{ article.author.url }}">{{ article.author }}</a>
+      {% if AUTHORS_SAVE_AS %}
+        <a href="{{ SITEURL }}/{{ article.author.url }}">{{ article.author }}</a>
+      {% else %}
+        {{ article.author }}
+      {% endif %}
     </span>
   </span>
   {% include '_includes/article_time.html' %}


### PR DESCRIPTION
There seems to be no point in linking to the author's index page listing all
articles of that author if there is only one author. If the pelican
configuration states that no overview page of all authors should be generated
we can assume only one author exists and thus not link the author's name in the
article footer.