### PR TITLE
Adding support for Google AdSense in Sidebar.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,11 @@ Extra google plus options (default values are shown):
 - ``GOOGLE_PLUS_ONE``: ``False`` show +1 button
 - ``GOOGLE_PLUS_HIDDEN``: ``False`` hide the google plus sidebar link.
 
+Google AdSense Sidebar
+----------------------
+
+- ``GOOGLE_ADSENSE_CODE``: JavaScript `snippet <https://support.google.com/adsense/answer/181960>`_ to enable Google AdSense.
+
 Google Analytics
 -------------
 
@@ -81,7 +86,7 @@ Sidebar image
 - ``SEARCH_BOX``: set to true to enable site search box
 - ``SITESEARCH``: [default: 'http://google.com/search'] search engine to which
   search form should be pointed (optional)
-  
+
 QR Code generation
 -------------
 
@@ -125,7 +130,7 @@ Authors
 - `Jake Vanderplas`_: Work on Twitter, Google plus, Facebook, and Disqus plugins.
 - `Nicholas Terwoord`_: Additional fixes for Twitter, Google plus, and site search
 - `Mortada Mehyar`_: Display advertising features for Google Analytics
-- ... and many others. `Check the contributors`_. 
+- ... and many others. `Check the contributors`_.
 
 
 .. _`Pelican`: http://getpelican.com

--- a/templates/_includes/google_adsense.html
+++ b/templates/_includes/google_adsense.html
@@ -1,0 +1,5 @@
+{% if GOOGLE_ADSENSE_CODE %}
+<section>
+  {{ GOOGLE_ADSENSE_CODE }}
+</section>
+{% endif %}

--- a/templates/_includes/sidebar.html
+++ b/templates/_includes/sidebar.html
@@ -38,4 +38,5 @@
   {% include '_includes/links.html' %}
   {% include '_includes/twitter_sidebar.html' %}
   {% include '_includes/gplus_sidebar.html' %}
+  {% include '_includes/google_adsense.html' %}
 </aside>


### PR DESCRIPTION
For some context, I [load][1] this code from a [file][2] in my blog (and only use the AdSense code when building the production blog on Travis).

[1]: https://github.com/dhermes/bossylobster-blog/blob/8beb9af2f23a9c31c2a55c57c50c344eca8975b0/pelicanconf.py#L136
[2]: https://github.com/dhermes/bossylobster-blog/blob/8beb9af2f23a9c31c2a55c57c50c344eca8975b0/google_adsense_code.html