### PR TITLE
Adding support for custom archives title.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -164,6 +164,12 @@ to enable in each respective channel, your post metadata needs to specify:
 - ``use_open_graph: true``: For Facebook specific meta tags.
 - ``use_twitter_card: true``: For Twitter specific meta tags.
 
+Archive Title
+-------------
+
+- ``ARCHIVE_TITLE``: Custom page title for ``archives.html``. Default is
+  ``"Blog Archive"``.
+
 Contribute
 ----------
 

--- a/templates/_includes/analytics.html
+++ b/templates/_includes/analytics.html
@@ -5,7 +5,7 @@
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-    ga('create', '{{GOOGLE_UNIVERSAL_ANALYTICS}}', '{{GOOGLE_UNIVERSAL_ANALYTICS_COOKIEDOMAIN|default("auto")}}');
+    ga('create', '{{GOOGLE_UNIVERSAL_ANALYTICS}}', '{{GOOGLE_UNIVERSAL_ANALYTICS_COOKIEDOMAIN|default('auto')}}');
 
     {% if GOOGLE_ANALYTICS_DISPLAY_FEATURES %}
     ga('require', 'displayfeatures');

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -1,13 +1,13 @@
 {% extends "base.html" %}
-{% block title %}Blog Archive &mdash; {{ SITENAME }}{% endblock %}
+{% block title %}{{ ARCHIVE_TITLE|default('Blog Archive') }} &mdash; {{ SITENAME }}{% endblock %}
 {% block content %}
 <div>
-	<article role="article">
-    	<header>
-    		<h1 class="entry-title">Blog Archive</h1>
-    	</header>
+  <article role="article">
+      <header>
+        <h1 class="entry-title">{{ ARCHIVE_TITLE|default('Blog Archive') }}</h1>
+      </header>
 
-    	<div id="blog-archives">
+      <div id="blog-archives">
         {% for year, date_year in dates|groupby('date.year')|sort(reverse=NEWEST_FIRST_ARCHIVES) %}
             <h2>{{ year }}</h2>
             {% for month, articles in date_year|groupby('date.month')|sort(reverse=NEWEST_FIRST_ARCHIVES) %}
@@ -24,13 +24,13 @@
                                 <a class='category' href='{{ SITEURL }}/{{ article.category.url }}'>{{ article.category }}</a>
                                 {{ tag }}
                             </span>
-			    {% include '_includes/article_stats.html' %}
+                            {% include '_includes/article_stats.html' %}
                         </footer>
                     </article>
                 {% endfor %}
             {% endfor %}
         {% endfor %}
-	    </div>
+      </div>
     </article>
 </div>
 {% endblock %}

--- a/templates/period_archives.html
+++ b/templates/period_archives.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
-{% block title %}Archive &ndash; {{ period[2] }} {{ period[1] }} {{ period[0]  }} &mdash; {{ SITENAME }}{% endblock %}
+{% block title %}{{ ARCHIVE_TITLE|default('Blog Archive') }} &ndash; {{ period[2] }} {{ period[1] }} {{ period[0]  }} &mdash; {{ SITENAME }}{% endblock %}
 {% block content %}
 <div>
 	<article role="article">
     	<header>
-    	  <h1 class="entry-title">Blog Archive &ndash; {{ period[2] }} {{ period[1] }} {{ period[0]  }}</h1>
+    	  <h1 class="entry-title">{{ ARCHIVE_TITLE|default('Blog Archive') }} &ndash; {{ period[2] }} {{ period[1] }} {{ period[0]  }}</h1>
     	</header>
 
     	<div id="blog-archives">


### PR DESCRIPTION
Also using single quotes in all Jinja2 |default uses and gets rid of tabs / inconsistent whitespace in `archives.html`.