### PR TITLE
Escaping title for Disqus JavaScript variable.

### DIFF
--- a/templates/_includes/disqus_script.html
+++ b/templates/_includes/disqus_script.html
@@ -1,15 +1,15 @@
 {% if DISQUS_SITENAME %}
-	<script type="text/javascript">
-	  var disqus_shortname = '{{ DISQUS_SITENAME }}';
-      {% if article %}
-          var disqus_identifier = '/{{ article.url }}';
-          var disqus_url = '{{ SITEURL }}/{{ article.url }}';
-          var disqus_title = '{{ article.title }}';
-      {% endif %}
-	  (function() {
-	    var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-	    dsq.src = "//" + disqus_shortname + '.disqus.com/embed.js';
-	    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-	   })();
-	</script>
+  <script type="text/javascript">
+    var disqus_shortname = '{{ DISQUS_SITENAME }}';
+    {% if article %}
+    var disqus_identifier = '/{{ article.url }}';
+    var disqus_url = '{{ SITEURL }}/{{ article.url }}';
+    var disqus_title = '{{ article.title|replace("'", "\\'") }}';
+    {% endif %}
+    (function() {
+      var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+      dsq.src = "//" + disqus_shortname + '.disqus.com/embed.js';
+      (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+     })();
+  </script>
 {% endif %}


### PR DESCRIPTION
Causes the JS to fail if a title contains a single quote
(for example an apostrophe).

Also making whitespace consistent and removing tab
characters in 'disqus_script.html'.