### PR TITLE
Enable ability to add social markup tags to <head>.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ Sidebar image
 - ``SEARCH_BOX``: set to true to enable site search box
 - ``SITESEARCH``: [default: 'http://google.com/search'] search engine to which
   search form should be pointed (optional)
-  
+
 QR Code generation
 -------------
 
@@ -132,6 +132,38 @@ Main Navigation (menu bar)
 - ``MENUITEMS_AFTER``: ``()`` show static links (after categories)
   e.g.: ``MENUITEMS_AFTER = ( ('link2', '/static/file2.pdf'), )``
 
+Markup for Social Sharing
+-------------------------
+
+In order to specify page title, description, image and other metadata for
+customized social sharing (e.g.
+`Twitter cards <https://dev.twitter.com/cards/overview>`_), you can add
+the following metadata to each post:
+
+- ``title``: The title of the post. This is expected for any post.
+- ``description``: A long form description of the post.
+- ``social_image``: A path to an image, relative to ``SITEURL``. This image
+                    will show up next to the other information in social
+                    shares.
+- ``twitter_site``: A Twitter handle, e.g. ``@getpelican`` for the owner
+                    of the site.
+` ``twitter_creator``: A Twitter handle, e.g. ``@getpelican`` for the author
+                       of the post.
+
+In addition, you can provide a default post image (instead of setting
+``social_image`` in the post metadata), by setting ``SOCIAL_IMAGE`` in your
+``pelicanconf``.
+
+These can be used for social sharing on Google+, Twitter, and Facebook as
+well as provide more detailed page data for Google Search. In order
+to enable in each respective channel, your post metadata needs to specify:
+
+- ``title``: The title of the post. This is expected for any post.
+
+- ``use_schema_org: true``: For Google and Google+ specific meta tags.
+- ``use_open_graph: true``: For Facebook specific meta tags.
+- ``use_twitter_card: true``: For Twitter specific meta tags.
+
 Contribute
 ----------
 
@@ -148,7 +180,7 @@ Authors
 - `Jake Vanderplas`_: Work on Twitter, Google plus, Facebook, and Disqus plugins.
 - `Nicholas Terwoord`_: Additional fixes for Twitter, Google plus, and site search
 - `Mortada Mehyar`_: Display advertising features for Google Analytics
-- ... and many others. `Check the contributors`_. 
+- ... and many others. `Check the contributors`_.
 
 
 .. _`Pelican`: http://getpelican.com

--- a/templates/_includes/social_markup.html
+++ b/templates/_includes/social_markup.html
@@ -1,0 +1,42 @@
+{% if article.use_schema_org %}
+<!-- Schema.org markup for Google+ -->
+<meta itemprop="name" content="{{ article.title }}" />
+<meta itemprop="description" content="{{ article.description }}" />
+{% if article.social_image %}
+<meta itemprop="image" content="{{ SITEURL }}/{{ article.social_image }}" />
+{% elif SOCIAL_IMAGE %}
+<meta itemprop="image" content="{{ SITEURL }}/{{ SOCIAL_IMAGE }}" />
+{% endif %}
+{% endif %}
+
+{% if article.use_open_graph %}
+<!-- Open Graph data -->
+<meta property="og:type" content="article" />
+<meta property="og:title" content="{{ article.title }}" />
+{% if article.social_image %}
+<meta property="og:image" content="{{ SITEURL }}/{{ article.social_image }}" />
+{% elif SOCIAL_IMAGE %}
+<meta property="og:image" content="{{ SITEURL }}/{{ SOCIAL_IMAGE }}" />
+{% endif %}
+<meta property="og:description" content="{{ article.description }}" />
+{% endif %}
+
+{% if article.use_twitter_card %}
+<!-- Twitter Card data -->
+<meta name="twitter:card" content="summary" />
+{% if article.twitter_site %}
+<meta name="twitter:site" content="{{ article.twitter_site }}" />
+{% else %}
+<meta name="twitter:site" content="{{ TWITTER_USER }}" />
+{% endif %}
+<meta name="twitter:title" content="{{ article.title }}" />
+<meta name="twitter:description" content="{{ article.description }}" />
+{% if article.twitter_creator %}
+<meta name="twitter:creator" content="{{ article.twitter_creator }}" />
+{% endif %}
+{% if article.social_image %}
+<meta name="twitter:image" content="{{ SITEURL }}/{{ article.social_image }}" />
+{% elif SOCIAL_IMAGE %}
+<meta name="twitter:image" content="{{ SITEURL }}/{{ SOCIAL_IMAGE }}" />
+{% endif %}
+{% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,10 +2,17 @@
 <!--[if IEMobile 7 ]><html class="no-js iem7"><![endif]-->
 <!--[if lt IE 9]><html class="no-js lte-ie8"><![endif]-->
 <!--[if (gt IE 8)|(gt IEMobile 7)|!(IEMobile)|!(IE)]><!--><html class="no-js" lang="en"><!--<![endif]-->
+{% if article and article.use_schema_org %}
+<head itemscope itemtype="http://schema.org/Article">
+{% else %}
 <head>
+{% endif %}
   <meta charset="utf-8">
   <title>{% block title %}{{ SITENAME }}{% endblock %}</title>
   <meta name="author" content="{{ AUTHOR }}">
+  {% if article and article.description %}
+  <meta name="description" content="{{ article.description }}" />
+  {% endif %}
 
   {% if FEED_FEEDBURNER %}
   <link href="http://feeds.feedburner.com/{{ FEED_FEEDBURNER }}" type="application/rss+xml" rel="alternate"
@@ -23,6 +30,10 @@
 
   {% if EXTRA_HEADER %}
     {{ EXTRA_HEADER }}
+  {% endif %}
+
+  {% if article %}
+  {% include '_includes/social_markup.html' %}
   {% endif %}
 
   <!-- http://t.co/dKP3o1e -->


### PR DESCRIPTION
h/t to https://github.com/DandyDev/pelican-bootstrap3/

Note I am not an expert on social meta tags (or on this theme / pelican) and am open to feedback / pushback / guidance / etc.

I have implemented this on one [post][1] so far. See links for [Twitter card][2] and [Google+ share][3].

[1]: https://raw.githubusercontent.com/dhermes/bossylobster-blog/8beb9af2f23a9c31c2a55c57c50c344eca8975b0/content/2014-12-31-constantly-seek-criticism.md
[2]: https://twitter.com/bossylobster/status/550369218705641472
[3]: https://plus.google.com/+DannyHermes/posts/esQMRGPE6T6