### PR TITLE
Fix #81 Fix for configurable disqus_identifier from article metadata

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,6 +106,16 @@ website.
   is being served from without a trailing slash. Example:
   ``http://example.com``
 
+Disqus Identifier
+-----------------
+
+If you are migrated from wordpress or any CMS to pelican, the disqus identifier is different there. In pelican the disqus identifier is URL of an article. So you will lose Disqus discussion for that article because Disqus identifier for that article is changed. To override the disqus identifier of an article
+
+- ``disqus_identifier``: set this property in your article meta data. Set it to any unique string you want. It won’t be affected by the article URL.
+
+If you choose not to use ``disqus_identifier``, defaults article URL passes to Disqus as identifier.  
+
+
 X min read
 ----------
 

--- a/templates/_includes/disqus_script.html
+++ b/templates/_includes/disqus_script.html
@@ -2,7 +2,11 @@
   <script type="text/javascript">
     var disqus_shortname = '{{ DISQUS_SITENAME }}';
     {% if article %}
-    var disqus_identifier = '/{{ article.url }}';
+      {% if article.disqus_identifier %}
+          var disqus_identifier = '{{ article.disqus_identifier }}';
+      {% else %}
+          var disqus_identifier = '/{{ article.url }}';
+      {% endif %}
     var disqus_url = '{{ SITEURL }}/{{ article.url }}';
     var disqus_title = '{{ article.title|replace("'", "\\'") }}';
     {% endif %}


### PR DESCRIPTION
- The article metadata `:disqus_identifier:` will override the autogenerated disqus_identifier variable
- refer bug #81
