### PR TITLE
Load scripts before plugins that might use them.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -64,6 +64,10 @@
   {% if page and page.latex %}
     {{ page.latex }}
   {% endif %}
+
+  <script src="{{ SITEURL }}/theme/js/modernizr-2.0.js"></script>
+  <script src="{{ SITEURL }}/theme/js/ender.js"></script>
+  <script src="{{ SITEURL }}/theme/js/octopress.js" type="text/javascript"></script>
 </head>
 
 <body>
@@ -76,9 +80,6 @@
     </div>
   </div>
   <footer role="contentinfo">{% include '_includes/footer.html' %}</footer>
-  <script src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/js/modernizr-2.0.js"></script>
-  <script src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/js/ender.js"></script>
-  <script src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/js/octopress.js" type="text/javascript"></script>
   {% include '_includes/after_footer.html' %}
 </body>
 </html>


### PR DESCRIPTION
Body elements are loaded in the order that they are seen; by loading
at the end of the body, they are not available for content that needs them,
like the github plugin in the sidebar. For the github plugin, this results
in a '$ is not defined' error and the repo list is never updated. Moving
the scripts to <head> ensures the scripts are loaded before dependent
content.

Update: note that this fixes #79.
