### PR TITLE
Provide a place for custom CSS (alternate fix for #52)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,6 +144,12 @@ Main Navigation (menu bar)
 - ``MENUITEMS_AFTER``: ``()`` show static links (after categories)
   e.g.: ``MENUITEMS_AFTER = ( ('link2', '/static/file2.pdf'), )``
 
+Custom CSS
+----------
+
+- ``CUSTOM_CSS_FILE``: ``filename_path`` Specify a custom CSS file to be applied
+  to all pages, e.g.: ``CUSTOM_CSS_FILE = 'static/css/custom.css'``
+
 Markup for Social Sharing
 -------------------------
 

--- a/templates/_includes/sidebar.html
+++ b/templates/_includes/sidebar.html
@@ -14,7 +14,7 @@
       {% endfor %}
     </ul>
   </section>
-  {% if categories %}
+  {% if categories and DISPLAY_CATEGORIES_ON_MENU %}
   <section>
       
     <h1>Categories</h1>

--- a/templates/base.html
+++ b/templates/base.html
@@ -53,6 +53,8 @@
 
   <link href="{{ SITEURL }}/{{ THEME_STATIC_DIR}}/css/{{ CSS_FILE }}" media="screen, projection"
         rel="stylesheet" type="text/css">
+  <link href="{{ SITEURL }}/static/css/{{ CUSTOM_CSS_FILE }}" media="screen, projection"
+	rel="stylesheet" type="text/css">
 
   <link href="//fonts.googleapis.com/css?family=PT+Serif:regular,italic,bold,bolditalic"
         rel="stylesheet" type="text/css">

--- a/templates/base.html
+++ b/templates/base.html
@@ -54,7 +54,7 @@
   <link href="{{ SITEURL }}/{{ THEME_STATIC_DIR}}/css/{{ CSS_FILE }}" media="screen, projection"
         rel="stylesheet" type="text/css">
   {% if CUSTOM_CSS_FILE %}
-  <link href="{{ SITEURL }}/static/css/{{ CUSTOM_CSS_FILE }}" media="screen, projection"
+  <link href="{{ SITEURL }}/{{ CUSTOM_CSS_FILE }}" media="screen, projection"
 	rel="stylesheet" type="text/css">
   {% endif %}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -53,8 +53,10 @@
 
   <link href="{{ SITEURL }}/{{ THEME_STATIC_DIR}}/css/{{ CSS_FILE }}" media="screen, projection"
         rel="stylesheet" type="text/css">
+  {% if CUSTOM_CSS_FILE %}
   <link href="{{ SITEURL }}/static/css/{{ CUSTOM_CSS_FILE }}" media="screen, projection"
 	rel="stylesheet" type="text/css">
+  {% endif %}
 
   <link href="//fonts.googleapis.com/css?family=PT+Serif:regular,italic,bold,bolditalic"
         rel="stylesheet" type="text/css">


### PR DESCRIPTION
This seems like it would be a better way to accommodate things like custom header pictures/colors [Issue #52](https://github.com/duilio/pelican-octopress-theme/issues/52) I use this locally with the following in my pelicanconf.py:

`CUSTOM_CSS_FILE = 'custom.css'`

and add `static` to my list of `STATIC_PATHS`. This way I (hopefully in the future) won't need to maintain a long-running fork of your theme.